### PR TITLE
cache aggressive illegal item search results

### DIFF
--- a/protocol3/src/main/java/protocol3/backend/Config.java
+++ b/protocol3/src/main/java/protocol3/backend/Config.java
@@ -9,7 +9,7 @@ public class Config {
 
 	private static HashMap<String, String> _values = new HashMap<String, String>();
 
-	public static int version = 18;
+	public static int version = 19;
 
 	public static String getValue(String key)
 	{

--- a/protocol3/src/main/java/protocol3/backend/LruCache.java
+++ b/protocol3/src/main/java/protocol3/backend/LruCache.java
@@ -1,0 +1,20 @@
+package protocol3.backend;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/* least recently used cache */
+public class LruCache<K, V> extends LinkedHashMap<K, V> {
+	private int cacheSize;
+
+	public LruCache(int cacheSize)
+	{
+		super(cacheSize, 0.75f, true);
+		this.cacheSize = cacheSize;
+	}
+
+	protected boolean removeEldestEntry(Map.Entry<K, V> eldest)
+	{
+		return size() >= cacheSize;
+	}
+}

--- a/protocol3/src/main/java/protocol3/events/Move.java
+++ b/protocol3/src/main/java/protocol3/events/Move.java
@@ -35,6 +35,8 @@ public class Move implements Listener
 	private static LruCache<Player, LruCache<Chunk, Boolean> > playerChunks
 		= new LruCache<>(Integer.parseInt(Config.getValue("item.illegal.agro.player_count")));
 
+	private static long lastCacheFlush = System.currentTimeMillis() / 1000;
+
 	static Random r = new Random();
 
 	@EventHandler
@@ -83,6 +85,7 @@ public class Move implements Listener
 
 		// -- ILLEGAL PLACEMENT PATCH -- //
 		boolean illegalItemAgro = Boolean.parseBoolean(Config.getValue("item.illegal.agro"));
+		int cacheFlushPeriod = Integer.parseInt(Config.getValue("item.illegal.agro.flush_period"));
 
 		// Check every chunk the player enters
 
@@ -135,6 +138,18 @@ public class Move implements Listener
 			if (illegalItemAgro)
 			{
 				boolean doAgroCheck = true;
+
+				// flush chunks if it's been long enough
+				if (cacheFlushPeriod > 0)
+				{
+					long now = System.currentTimeMillis() / 1000;
+					if (now - lastCacheFlush >= cacheFlushPeriod)
+					{
+						System.out.println("[protocol3] flushing agro chunk caches");
+						playerChunks.clear();
+						lastCacheFlush = now;
+					}
+				}
 
 				LruCache<Chunk, Boolean> currentPlayerChunks = playerChunks.get(p);
 

--- a/protocol3/src/main/java/protocol3/events/Move.java
+++ b/protocol3/src/main/java/protocol3/events/Move.java
@@ -32,9 +32,8 @@ public class Move implements Listener
 	public static HashMap<UUID, Chunk> lastChunks = new HashMap<UUID, Chunk>();
 
 	// per-player cache of chunks that have been checked aggressively for illegal items
-	// TODO make the 64 player number tunable, it should always exceed the normal
-	// player count, but not by too much
-	private static LruCache<Player, LruCache<Chunk, Boolean> > playerChunks = new LruCache<>(64);
+	private static LruCache<Player, LruCache<Chunk, Boolean> > playerChunks
+		= new LruCache<>(Integer.parseInt(Config.getValue("item.illegal.agro.player_count")));
 
 	static Random r = new Random();
 
@@ -142,7 +141,7 @@ public class Move implements Listener
 				// new player, make a new cache
 				if (currentPlayerChunks == null)
 				{
-					currentPlayerChunks = new LruCache<>(1024); // TODO make this a tunable
+					currentPlayerChunks = new LruCache<>(Integer.parseInt(Config.getValue("item.illegal.agro.chunk_count")));
 					playerChunks.put(p, currentPlayerChunks);
 				}
 

--- a/protocol3/src/main/resources/config.txt
+++ b/protocol3/src/main/resources/config.txt
@@ -3,7 +3,7 @@
 // ########################################### //
 
 // Internal use only. Do not change or you'll break the entire thing.
-config.version = 18
+config.version = 19
 
 // ------------------------ //
 // --- MOVEMENT PATCHES --- //
@@ -56,6 +56,13 @@ item.illegal.invalid = false
 // Enable or disable aggressive checks. false = disabled true = enabled [default]
 // Can cause some lag on lower-end servers
 item.illegal.agro = true
+
+// Number of players to cache chunks for in agro check mode
+// Set this to a number a little larger than the typical player pop
+item.illegal.agro.player_count = 40
+
+// Number of chunks per player to cache
+item.illegal.agro.chunk_count = 1024
 
 // -------------- //
 // --- VOTING --- //

--- a/protocol3/src/main/resources/config.txt
+++ b/protocol3/src/main/resources/config.txt
@@ -64,6 +64,10 @@ item.illegal.agro.player_count = 40
 // Number of chunks per player to cache
 item.illegal.agro.chunk_count = 1024
 
+// How frequently to flush the cache
+// Set to -1 to disable
+item.illegal.agro.flush_period = 3600
+
 // -------------- //
 // --- VOTING --- //
 // -------------- //


### PR DESCRIPTION
When doing agro illegal item checks, cache the results in a per-player LRU. As long as players don't stray far from busy chunks (default: 1024 chunks) the agro check won't refire. This gracefully handles players who are traveling and stationary players by keeping the caches per player.

Should help #24