### PR TITLE
dupehand: check syntax of command input

### DIFF
--- a/protocol3/src/main/java/protocol3/commands/DupeHand.java
+++ b/protocol3/src/main/java/protocol3/commands/DupeHand.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import net.md_5.bungee.api.chat.TextComponent;
 import protocol3.backend.Config;
 import protocol3.backend.PlayerMeta;
 
@@ -30,8 +31,17 @@ public class DupeHand implements CommandExecutor {
 			player.kickPlayer("§6get fucked newfag [pog]");
 			return true;
 		} else {
-			int rewardMultiplier = Integer.parseInt(Config.getValue("vote.multiplier"));
+			if (args.length != 1) {
+				sender.spigot().sendMessage(new TextComponent("§cInvalid syntax. Syntax: /dupehand [name]"));
+				return true;
+			}
 			Player player = Bukkit.getPlayer(args[0]);
+			if (player == null) {
+				sender.spigot().sendMessage(new TextComponent("§cPlayer is not online."));
+				return true;
+			}
+
+			int rewardMultiplier = Integer.parseInt(Config.getValue("vote.multiplier"));
 			ItemStack itemInHand = player.getInventory().getItemInMainHand();
 			if (Config.getValue("vote.heal").equals("true")) {
 				player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());


### PR DESCRIPTION
previous code would throw exceptions if player was not provided or
player didn't exist. this gracefully warns the user and provides syntax
on error