### PR TITLE
introduce command to make bedrock solidification optional

### DIFF
--- a/protocol3/src/main/java/protocol3/backend/Config.java
+++ b/protocol3/src/main/java/protocol3/backend/Config.java
@@ -9,7 +9,7 @@ public class Config {
 
 	private static HashMap<String, String> _values = new HashMap<String, String>();
 
-	public static int version = 19;
+	public static int version = 20;
 
 	public static String getValue(String key)
 	{

--- a/protocol3/src/main/java/protocol3/events/Move.java
+++ b/protocol3/src/main/java/protocol3/events/Move.java
@@ -110,6 +110,7 @@ public class Move implements Listener
 		{
 			boolean containsSpawner = false;
 			boolean portalsIllegal = false;
+			boolean solidifyBedrock = Boolean.parseBoolean(Config.getValue("movement.block.chunkcheck.solidify_bedrock"));
 			Chunk c = p.getLocation().getChunk();
 
 			// Portals dont spawn PAST! a 25000 block radius of spawn
@@ -247,14 +248,14 @@ public class Move implements Listener
 						}
 
 						// make sure the floor is solid in both dimensions at y=1
-						if (y == 1 && !(block.getType().equals(Material.BEDROCK)))
+						if (solidifyBedrock && y == 1 && !(block.getType().equals(Material.BEDROCK)))
 						{
 							block.setType(Material.BEDROCK);
 							continue;
 						}
 
 						// make sure the nether ceiling is solid at y=127
-						if (inNether && y == 127 && !(block.getType().equals(Material.BEDROCK)))
+						if (solidifyBedrock && inNether && y == 127 && !(block.getType().equals(Material.BEDROCK)))
 						{
 							block.setType(Material.BEDROCK);
 							continue;

--- a/protocol3/src/main/resources/config.txt
+++ b/protocol3/src/main/resources/config.txt
@@ -3,7 +3,7 @@
 // ########################################### //
 
 // Internal use only. Do not change or you'll break the entire thing.
-config.version = 19
+config.version = 20
 
 // ------------------------ //
 // --- MOVEMENT PATCHES --- //
@@ -17,6 +17,10 @@ movement.block.floor = true
 
 // Enable or disable illegal placement protection. false = disabled true = enabled [default]
 movement.block.chunkcheck = true
+
+// Solidify the floor of the overworld and nether and the roof of the nether. false = disabled true = enabled [default]
+// WARNING: has a major impact on performance when multiple players are traveling
+movement.block.solidify_bedrock = true
 
 // --------------------- //
 // --- BLOCK PATCHES --- //

--- a/protocol3/src/main/resources/config.txt
+++ b/protocol3/src/main/resources/config.txt
@@ -20,7 +20,7 @@ movement.block.chunkcheck = true
 
 // Solidify the floor of the overworld and nether and the roof of the nether. false = disabled true = enabled [default]
 // WARNING: has a major impact on performance when multiple players are traveling
-movement.block.solidify_bedrock = true
+movement.block.chunkcheck.solidify_bedrock = true
 
 // --------------------- //
 // --- BLOCK PATCHES --- //

--- a/protocol3/src/main/resources/config.txt
+++ b/protocol3/src/main/resources/config.txt
@@ -18,9 +18,10 @@ movement.block.floor = true
 // Enable or disable illegal placement protection. false = disabled true = enabled [default]
 movement.block.chunkcheck = true
 
-// Solidify the floor of the overworld and nether and the roof of the nether. false = disabled true = enabled [default]
-// WARNING: has a major impact on performance when multiple players are traveling
-movement.block.chunkcheck.solidify_bedrock = true
+// Solidify the floor of the overworld and nether and the roof of the nether. false = disabled [default] true = enabled
+// WARNING: has a major impact on performance when multiple players are traveling. DO NOT KEEP THIS OPTION ON! 
+// Use it in short bursts if you need to repair bedrock layers.
+movement.block.chunkcheck.solidify_bedrock = false
 
 // --------------------- //
 // --- BLOCK PATCHES --- //


### PR DESCRIPTION
The previously default behavior was accounting for up to 33% of tick
time with just one user traveling. This patch makes the behavior
optional for server owners seeking more TPS.

Fixes #36 