### PR TITLE
(performance) remove wither skulls once per second, not on entity add

### DIFF
--- a/protocol3/src/main/java/protocol3/Main.java
+++ b/protocol3/src/main/java/protocol3/Main.java
@@ -56,6 +56,7 @@ public class Main extends JavaPlugin implements Listener {
 		getServer().getScheduler().scheduleSyncRepeatingTask(this, new AutoAnnouncer(), 15000L, 15000L);
 		getServer().getScheduler().scheduleSyncRepeatingTask(this, new ProcessPlaytime(), 20L, 20L);
 		getServer().getScheduler().scheduleSyncRepeatingTask(this, new OnTick(), 1L, 1L);
+		getServer().getScheduler().scheduleSyncRepeatingTask(this, new LagPrevention(), 20L, 20L);
 
 		// Load listeners
 		getServer().getPluginManager().registerEvents(new Chat(), this);

--- a/protocol3/src/main/java/protocol3/events/LagPrevention.java
+++ b/protocol3/src/main/java/protocol3/events/LagPrevention.java
@@ -15,7 +15,7 @@ import org.bukkit.event.entity.EntitySpawnEvent;
 
 import protocol3.backend.Config;
 
-public class LagPrevention implements Listener {
+public class LagPrevention implements Listener, Runnable {
 	public static int currentWithers = 0;
 
 	@EventHandler
@@ -30,8 +30,6 @@ public class LagPrevention implements Listener {
 			}
 			currentWithers = getWithers();
 		}
-
-		removeOldSkulls();
 	}
 
 	public static int getWithers() {
@@ -86,5 +84,11 @@ public class LagPrevention implements Listener {
 		});
 
 		return toRet[0];
+	}
+
+	// clear skulls every 20 ticks (~1 sec)
+	@Override
+	public void run() {
+		removeOldSkulls();
 	}
 }


### PR DESCRIPTION
The previous behavior was contributing to lag when many entities were
being added to the game quickly (example: lots of TNT exploding).